### PR TITLE
Check out SPDK and run on PR/manually

### DIFF
--- a/.github/actions/checkout_gerrit/action.yml
+++ b/.github/actions/checkout_gerrit/action.yml
@@ -1,0 +1,39 @@
+name: 'Checkout from Gerrit'
+description: 'Checkout SPDK, using provided patch set or master'
+
+inputs:
+  gerrit_ref:
+    description: 'Reference to specific Gerrit patch set'
+    required: false
+    default: ''
+  spdk_path:
+    description: 'Path where SPDK will be cloned'
+    required: false
+    default: '$GITHUB_WORKSPACE/spdk'
+  spdk_branch:
+    description: 'Branch to clone'
+    required: false
+    default: 'master'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout the spdk repo from GitHub
+      uses: actions/checkout@v4
+      with:
+        repository: spdk/spdk
+        ref: ${{ inputs.spdk_branch }}
+        submodules: recursive
+        fetch-tags: true
+        path: ${{ inputs.spdk_path }}
+    - name: Fetch the specific change from Gerrit
+      if: ${{ inputs.gerrit_ref != '' }}  # Skip if only pulling from GitHub
+      run: |
+        git -C ${{ inputs.spdk_path }} fetch https://review.spdk.io/spdk/spdk ${{ inputs.gerrit_ref }} &&
+        git -C ${{ inputs.spdk_path }} checkout FETCH_HEAD &&
+        git -C ${{ inputs.spdk_path }} submodule update --init
+      shell: bash
+    - name: Log the last few commits
+      run: |
+        git -C ${{ inputs.spdk_path }} log --pretty=oneline -n 5
+      shell: bash

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -1,8 +1,7 @@
 name: SPDK per-patch tests
 
-# TODO: Add pull_request target to enable self-testing, now that we've commited
-# to using pull requests for spdk-ci development process.
 on:
+  pull_request:
   workflow_dispatch:
   repository_dispatch:
     types:

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -3,6 +3,7 @@ name: SPDK per-patch tests
 # TODO: Add pull_request target to enable self-testing, now that we've commited
 # to using pull requests for spdk-ci development process.
 on:
+  workflow_dispatch:
   repository_dispatch:
     types:
       - per-patch-event

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -4,6 +4,13 @@ name: SPDK per-patch common tests
 # Github runners, without any hardware-specific dependencies.
 
 on:
+  workflow_dispatch:
+    inputs:
+      gerrit_ref:
+        description: 'Gerrit refspec to test following refs/changes/${change_number: -2}/${change_number}/${patch_set} format'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       client_payload:
@@ -16,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       client_payload: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) || '' }}
+      gerrit_ref: ${{ inputs.gerrit_ref }}
       spdk_path: './spdk'
     steps:
       # Required to use locally defined actions
@@ -24,7 +32,7 @@ jobs:
       - name: Prepare SPDK repo by checking out from Gerrit
         uses: ./.github/actions/checkout_gerrit
         with:
-          gerrit_ref: ${{ env.client_payload != '' && env.client_payload.patchSet.ref || '' }}
+          gerrit_ref: ${{ env.client_payload != '' && env.client_payload.patchSet.ref || env.gerrit_ref }}
           spdk_path: ${{ env.spdk_path }}
       - name: Log the current state
         run: git -C ${{ env.spdk_path }} log --pretty=oneline -n 5

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -9,10 +9,14 @@ on:
       client_payload:
         required: false
         type: string
+        default: ''
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      client_payload: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) || '' }}
+      spdk_path: './spdk'
     steps:
       # Required to use locally defined actions
       - name: Checkout the spdk-ci repo locally
@@ -20,16 +24,20 @@ jobs:
       - name: Prepare SPDK repo by checking out from Gerrit
         uses: ./.github/actions/checkout_gerrit
         with:
-          gerrit_ref: ${{ fromJson(inputs.client_payload).patchSet.ref }}
-          spdk_path: './spdk'
+          gerrit_ref: ${{ env.client_payload != '' && env.client_payload.patchSet.ref || '' }}
+          spdk_path: ${{ env.spdk_path }}
       - name: Log the current state
-        run: git -C ./spdk log --pretty=oneline -n 5
+        run: git -C ${{ env.spdk_path }} log --pretty=oneline -n 5
       # Placeholder for the actual tests. Replace in future PRs.
       - name: Hello world
         run: |
           echo "Hello!"
+    outputs:
+      client_payload: ${{ env.client_payload }}
 
   report:
+    # Only run if it was triggered by Gerrit event, with JSON for it
+    if: ${{ needs.tests.outputs.client_payload != '' }}
     runs-on: ubuntu-latest
     needs:
       - tests
@@ -48,7 +56,7 @@ jobs:
           # For demonstration purposes, as not to set any actual vote and only comment.
           VOTE=0
 
-          curl -L -X POST https://review.spdk.io/a/changes/${{ fromJson(inputs.client_payload).change.number }}/revisions/${{ fromJson(inputs.client_payload).patchSet.number }}/review \
+          curl -L -X POST https://review.spdk.io/a/changes/${{ needs.client_payload.change.number }}/revisions/${{ needs.client_payload.patchSet.number }}/review \
           --user "${{ secrets.GERRIT_BOT_USER }}:${{ secrets.GERRIT_BOT_HTTP_PASSWD }}" \
           --header "Content-Type: application/json" \
           --data "{'message': '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID', 'labels': {'Verified': $VOTE}}" \

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -14,6 +14,16 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
+      # Required to use locally defined actions
+      - name: Checkout the spdk-ci repo locally
+        uses: actions/checkout@v4
+      - name: Prepare SPDK repo by checking out from Gerrit
+        uses: ./.github/actions/checkout_gerrit
+        with:
+          gerrit_ref: ${{ fromJson(inputs.client_payload).patchSet.ref }}
+          spdk_path: './spdk'
+      - name: Log the current state
+        run: git -C ./spdk log --pretty=oneline -n 5
       # Placeholder for the actual tests. Replace in future PRs.
       - name: Hello world
         run: |


### PR DESCRIPTION
This series first starts off by adding composite action `checkout_gerrit` that checks out SPDK from GitHub and fetches specific patch set from Gerrit.

Later added way to manually run both workflows for debugging purposes. Meanwhile the gerrit-webhook can now be triggered on new PRs.

Note that this can result in some steps/jobs being skipped, for example no reporting back to Gerrit is needed (nor it is set up for 'testing').