### PR TITLE
Fix voting on webhook triggered builds (again)

### DIFF
--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -23,7 +23,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      client_payload: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || '' }}
+      is_called: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || false }}
       gerrit_ref: ${{ inputs.gerrit_ref }}
       spdk_path: './spdk'
     steps:
@@ -40,11 +40,11 @@ jobs:
       run: |
         echo "Hello!"
     outputs:
-      client_payload: ${{ env.client_payload }}
+      is_called: ${{ env.is_called }}
 
   report:
     # Only run if it was triggered by Gerrit event, with JSON for it
-    if: ${{ needs.tests.outputs.client_payload != '' }}
+    if: ${{ needs.tests.outputs.is_called == 'true' }}
     runs-on: ubuntu-latest
     needs:
     - tests
@@ -63,7 +63,7 @@ jobs:
         # For demonstration purposes, as not to set any actual vote and only comment.
         VOTE=0
 
-        curl -L -X POST https://review.spdk.io/a/changes/${{ needs.tests.outputs.client_payload.change.number }}/revisions/${{ needs.tests.outputs.client_payload.patchSet.number }}/review \
+        curl -L -X POST https://review.spdk.io/a/changes/${{ fromJson(inputs.client_payload).change.number }}/revisions/${{ fromJson(inputs.client_payload).patchSet.number }}/review \
         --user "${{ secrets.GERRIT_BOT_USER }}:${{ secrets.GERRIT_BOT_HTTP_PASSWD }}" \
         --header "Content-Type: application/json" \
         --data "{'message': '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID', 'labels': {'Verified': $VOTE}}" \


### PR DESCRIPTION
Conditional using "client_payload" in "env" section resulted in either boolean (True) if payload was present or empty string if not. When "true", there was no way to extract change and patchset number in the "report" stage of the build.

Change variable name and set it to be either true/false instead of string.