### PR TITLE
ci: fixing `nvmf-tcp-vm-autotest` by adding  missing `xxd`

### DIFF
--- a/cijoe/workflows/build_qcow2_using_qemu.yaml
+++ b/cijoe/workflows/build_qcow2_using_qemu.yaml
@@ -55,6 +55,7 @@ steps:
   run: |
     dnf update -y
     dnf install -y git perl-JSON-PP
+    dnf install -y xxd # those are temporary here and will be moved to pkgdep.sh or autotest_setup.sh
     dnf autoremove -y
     dnf clean all -y
 


### PR DESCRIPTION
will be moved to `pkgdep.sh` or `autotest_setup.sh` after merging to spdk/spdk is re-enabled

see https://github.com/spdk/spdk/issues/3615#issuecomment-2674993586