### PR TITLE
Skip SPDK tests on certain pull requests

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -3,6 +3,9 @@ name: SPDK per-patch tests
 
 on:
   pull_request:
+    paths-ignore:
+    - '.github/workflows/selftest.yml'
+    - '.github/workflows/build_qcow2.yml'
   workflow_dispatch:
   repository_dispatch:
     types:


### PR DESCRIPTION
Skip running complete SPDK tests for pull requests done for:
* selftest.yml workflow - because it's just a set of pre-commit linters not affecting SPDK tests themselves.
* build_qcow2.yml - because the per-patch build triggered by the PR is still using qcow2 image which doesn't contain the changes from the PR.