### PR TITLE
Remove "sed" for autorun_post.py input files

### DIFF
--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -78,14 +78,6 @@ jobs:
         #       It's ~1GB with all it's dependecies, which is an overkill for
         #       a few table operations.
         sudo apt-get update && sudo apt-get install -y lcov python3-pandas
-
-        # Favourite part <3
-        # lcov when registers /opt/spdk/** paths for files when running in Qemu
-        # spawned by cijoe. But the working directory and paths are different
-        # in this step so need to replace them.
-        # TODO: This should be an option in autorun_post.py script itself.
-        sed -i -e "s#^SF:/[^/]*/spdk/#SF:$PWD/spdk/#" */cov_total.info
-
         spdk/autorun_post.py -s -d ./ -r ./spdk
 
     - name: Upload artifacts


### PR DESCRIPTION
Path replacement in input coverage files was moved to spdk/autorun_post.py itself.
See: https://review.spdk.io/c/spdk/spdk/+/25675

Tested at: https://github.com/karlatec/spdk-ci/actions/runs/13716702764