### PR TITLE
Fix spdk-common-tests workflow_call

### DIFF
--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       is_called: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || false }}
-      gerrit_ref: ${{ inputs.gerrit_ref }}
+      gerrit_ref: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload).patchSet.ref || inputs.gerrit_ref }}
     steps:
       # Required to use locally defined actions
     - name: Checkout the spdk-ci repo locally
@@ -34,7 +34,7 @@ jobs:
     - name: Prepare SPDK repo by checking out from Gerrit
       uses: ./.github/actions/checkout_gerrit
       with:
-        gerrit_ref: ${{ env.client_payload != '' && env.client_payload.patchSet.ref || env.gerrit_ref }}
+        gerrit_ref: ${{ env.gerrit_ref }}
         spdk_path: ${{ env.spdk_path }}
     - name: Create repository tarball
       run: tar -C ${{ env.spdk_path }} -czf repository.tar.gz .


### PR DESCRIPTION
... yet again! Recent builds triggered by Gerrit
webhook events show that SPDK source is checked-out using wrong respec.
This change fixes that.

For example:
[This change](https://review.spdk.io/c/spdk/spdk/+/25675/1#message-d7542753e7192a6eb24e8361aa6f6c03b56bc592) triggered https://github.com/spdk/spdk-ci/actions/runs/13716593637
but the build summary showed this as SPDK source being pulled for build:
```
  [SPDK Repository] GitHub: master
  Ref: d0bb35429 pkgdep: add xxd
```