### PR TITLE
build_qcow: cache the VM image for faster spin up of every job

### DIFF
--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -126,3 +126,11 @@ jobs:
         path: |
           ci/cijoe/cijoe-output
           fedora_40_x86_64.qcow2
+
+    - name: Cache qcow2 image
+      id: cache-qcow2
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          fedora_40_x86_64.qcow2
+        key: fedora_40_x86_64

--- a/.github/workflows/per_patch.yml
+++ b/.github/workflows/per_patch.yml
@@ -71,8 +71,17 @@ jobs:
         tar xzf repository.tar.gz --strip 1
         tar xzf abi.tar.gz --strip 1
 
+    - name: Restore qcow2 image from cache
+      id: restore-qcow2
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          fedora_40_x86_64.qcow2
+        key: fedora_40_x86_64
+
     - name: Download VM Qcow2 image artifact
       uses: actions/download-artifact@v4.1.8
+      if: ${{ hashFiles('fedora_40_x86_64.qcow2') == '' }}
       with:
         name: qcow2-build-artifacts
         github-token: ${{ github.token }}


### PR DESCRIPTION
Artifact download takes between 1-3 minutes on every job in the per-patch matrix. Instead we can cache the image reducing, download to 20-30 seconds.

Currently only the one and only VM image is cached. It takes almost 3GB, while cache is limited to 10GB. While we could explore caching other artifacts shared on per-patch basis - like SPDK repo, but we need to be careful not to boot the VM image out of the cache.

Note: used hashFiles() instead of checking cache-hit output, because it was not set despite hitting the cache.