### PR TITLE
build_qcow2: delete previous cached VM image

### DIFF
--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -124,6 +124,23 @@ jobs:
         compression-level: 0
         path: fedora_40_x86_64.qcow2
 
+  cache-qcow2:
+    needs: build-qcow2
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download VM Qcow2 image artifact
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: vm-image-fedora_40_x86_64
+
+    - name: Delete previous cache
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "vm-image-fedora_40_x86_64" --repo ${{ github.repository }} --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Cache qcow2 image
       id: cache-qcow2
       uses: actions/cache/save@v4


### PR DESCRIPTION
Turns out that saving cache entry with the same key, failed just with a warning. As a result cache for the image remained, and even future rebuilds succeeding - did not over-write the cache. Jobs would pull in the cached entry refering to the wrong VM image.

I think the idea for cache entries here would be to match based on some pattern for the most recent entry like:
`vm-image-fedora-x86_64-spdk_sha-spdk-ci_sha-timestamp`
So that every cache is unique and can be pattern matched to desired item. While the ones that are unused would be forced out of cache.
We still have to rethink image generation.

Instead of that for now just delete prior entry matched by the key and save new one.
Yes, there is no official action to do that so instead gh tool is used on an ubuntu-latest runner.