### PR TITLE
Combine job results into the summary

### DIFF
--- a/.github/actions/checkout_gerrit/action.yml
+++ b/.github/actions/checkout_gerrit/action.yml
@@ -27,10 +27,6 @@ runs:
       submodules: recursive
       fetch-tags: true
       path: ${{ inputs.spdk_path }}
-  - name: Start summary
-    run: |
-      echo "### Change Information" >> $GITHUB_STEP_SUMMARY
-    shell: bash
   - name: Fetch the specific change from Gerrit
     if: ${{ inputs.gerrit_ref != '' }}    # Skip if only pulling from GitHub
     working-directory: ${{ inputs.spdk_path }}
@@ -38,21 +34,9 @@ runs:
       git fetch https://review.spdk.io/spdk/spdk ${{ inputs.gerrit_ref }} &&
       git checkout FETCH_HEAD &&
       git submodule update --init
-      echo "- [SPDK Repository] Gerrit: ${{ inputs.gerrit_ref }}" >> $GITHUB_STEP_SUMMARY
-    shell: bash
-  - name: Add summary for GitHub repo
-    if: ${{ inputs.gerrit_ref == '' }}
-    run: |
-      echo "- [SPDK Repository] GitHub: ${{ inputs.spdk_branch }}" >> $GITHUB_STEP_SUMMARY
     shell: bash
   - name: Unshallow SPDK repository
     working-directory: ${{ inputs.spdk_path }}
     run: |
       git fetch --unshallow --recurse-submodules=no
-    shell: bash
-  - name: Add Information on the SPDK repository state
-    working-directory: ${{ inputs.spdk_path }}
-    run: |
-      CURRENT_REF=$(git log --pretty=oneline --abbrev-commit -n 1)
-      echo "- Ref: $CURRENT_REF" >> $GITHUB_STEP_SUMMARY
     shell: bash

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -27,4 +27,5 @@ jobs:
     uses: ./.github/workflows/summary.yml
     with:
       client_payload: ${{ toJson(github.event.client_payload) }}
+      result: ${{ needs.common.result }}
     secrets: inherit

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: ''
+      result:
+        required: true
+        type: string
+        default: 'failure'
 
 jobs:
   merge_outputs:
@@ -46,27 +50,32 @@ jobs:
         path: _autorun_summary
 
   report:
-    # Only run if it was triggered by Gerrit event, with JSON for it
-    if: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || false }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: merge_outputs
     steps:
+    - name: Vote count from workflows
+      id: vote_count
+      run: |
+        vote="-1"
+        message="Build failed. "
+        if [[ ${{ inputs.result }} == "success" ]]; then
+            vote="1"
+            message="Build successful. "
+        fi
+        # For demonstration purposes, as not to set any actual vote and only comment.
+        vote=0
+        message+="Results: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo "vote=$vote" >> $GITHUB_OUTPUT
+        echo "message=$message" >> $GITHUB_OUTPUT
+
     - name: Report results
+      # Only run if it was triggered by Gerrit event, with JSON for it
+      if: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || false }}
       run: |
         set -e
-
-        # Credits to https://github.com/spdk-community-ci/dispatcher/blob/main/.github/workflows/autorun.yml
-
-        VOTE=-1
-        if [[ "${{ needs.tests.result }}" == "success" ]]; then
-          VOTE=1
-        fi
-
-        # For demonstration purposes, as not to set any actual vote and only comment.
-        VOTE=0
-
         curl -L -X POST https://review.spdk.io/a/changes/${{ fromJson(inputs.client_payload).change.number }}/revisions/${{ fromJson(inputs.client_payload).patchSet.number }}/review \
         --user "${{ secrets.GERRIT_BOT_USER }}:${{ secrets.GERRIT_BOT_HTTP_PASSWD }}" \
         --header "Content-Type: application/json" \
-        --data "{'message': '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID', 'labels': {'Verified': $VOTE}}" \
+        --data "{'message': '${{ steps.vote_count.outputs.message }}', 'labels': {'Verified': ${{ steps.vote_count.outputs.vote }}}}" \
         --fail-with-body

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -9,8 +9,6 @@ on:
         type: string
         default: ''
 
-env:
-  spdk_path: './spdk'
 jobs:
   merge_outputs:
     # 22.04 used on purpose; it has lcov+gcov versions that are compatible with what
@@ -22,7 +20,7 @@ jobs:
       uses: actions/download-artifact@v4.1.8
       with:
         name: repo-spdk
-        path: ${{ github.workspace }}/spdk
+        path: ./spdk
 
     - name: Download artifact tarballs
       uses: actions/download-artifact@v4.1.8
@@ -31,14 +29,14 @@ jobs:
 
     - name: Show artifacts
       run: |
-        tar xf ${{ env.spdk_path }}/spdk.tar.gz -C ${{ env.spdk_path }}
+        tar xf ./spdk/spdk.tar.gz -C ./spdk
 
         # TODO: either use an official lcov image or create our own
         # TODO: get rid of pandas dependency in spdk/autorun_post.py.
         #       It's ~1GB with all it's dependecies, which is an overkill for
         #       a few table operations.
         sudo apt-get update && sudo apt-get install -y lcov python3-pandas
-        spdk/autorun_post.py -s -d ./ -r ./spdk
+        ./spdk/autorun_post.py -s -d ./ -r ./spdk
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -43,6 +43,14 @@ jobs:
         sudo apt-get update && sudo apt-get install -y lcov python3-pandas
         ./spdk/autorun_post.py -s -d ./_autorun_summary -r ./spdk
 
+    - name: Leave traces of the test run in the artifacts
+      run: |
+        summary="./_autorun_summary/github_run_summary"
+        echo "SPDK: $(git -C ./spdk show --pretty=format:"%H %s" -s HEAD)" > $summary
+        echo "SPDK-CI: ${{ github.sha }}" >> $summary
+        echo "GitHub run-id: ${{ github.run_id }}" >> $summary
+        cat "$summary" >> $GITHUB_STEP_SUMMARY
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4.4.0
       with:
@@ -65,16 +73,23 @@ jobs:
         fi
         # For demonstration purposes, as not to set any actual vote and only comment.
         vote=0
-        message+="Results: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        message+="Results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         echo "vote=$vote" >> $GITHUB_OUTPUT
         echo "message=$message" >> $GITHUB_OUTPUT
+        echo "$message" >> $GITHUB_STEP_SUMMARY
 
     - name: Report results
       # Only run if it was triggered by Gerrit event, with JSON for it
       if: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload) != '' || false }}
       run: |
         set -e
-        curl -L -X POST https://review.spdk.io/a/changes/${{ fromJson(inputs.client_payload).change.number }}/revisions/${{ fromJson(inputs.client_payload).patchSet.number }}/review \
+
+        change_num="${{ fromJson(inputs.client_payload).change.number }}"
+        patch_set="${{ fromJson(inputs.client_payload).patchSet.number }}"
+
+        echo "Gerrit: <https://review.spdk.io/c/spdk/spdk/+/$change_num/$patch_set>" >> $GITHUB_STEP_SUMMARY
+
+        curl -L -X POST https://review.spdk.io/a/changes/$change_num/revisions/$patch_set/review \
         --user "${{ secrets.GERRIT_BOT_USER }}:${{ secrets.GERRIT_BOT_HTTP_PASSWD }}" \
         --header "Content-Type: application/json" \
         --data "{'message': '${{ steps.vote_count.outputs.message }}', 'labels': {'Verified': ${{ steps.vote_count.outputs.vote }}}}" \

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/download-artifact@v4.1.8
       with:
         pattern: 'common-job-*'
+        path: ./_autorun_summary
 
     - name: Show artifacts
       run: |
@@ -36,17 +37,13 @@ jobs:
         #       It's ~1GB with all it's dependecies, which is an overkill for
         #       a few table operations.
         sudo apt-get update && sudo apt-get install -y lcov python3-pandas
-        ./spdk/autorun_post.py -s -d ./ -r ./spdk
+        ./spdk/autorun_post.py -s -d ./_autorun_summary -r ./spdk
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4.4.0
       with:
         name: _autorun_summary
-        path: |
-          doc
-          coverage
-          ut_coverage
-          post_process
+        path: _autorun_summary
 
   report:
     # Only run if it was triggered by Gerrit event, with JSON for it

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -32,16 +32,8 @@ jobs:
         pattern: 'common-job-*'
         path: ./_autorun_summary
 
-    - name: Show artifacts
-      run: |
-        tar xf ./spdk/spdk.tar.gz -C ./spdk
-
-        # TODO: either use an official lcov image or create our own
-        # TODO: get rid of pandas dependency in spdk/autorun_post.py.
-        #       It's ~1GB with all it's dependecies, which is an overkill for
-        #       a few table operations.
-        sudo apt-get update && sudo apt-get install -y lcov python3-pandas
-        ./spdk/autorun_post.py -s -d ./_autorun_summary -r ./spdk
+    - name: Untar the SPDK repo
+      run: tar xf ./spdk/spdk.tar.gz -C ./spdk
 
     - name: Leave traces of the test run in the artifacts
       run: |
@@ -51,11 +43,25 @@ jobs:
         echo "GitHub run-id: ${{ github.run_id }}" >> $summary
         cat "$summary" >> $GITHUB_STEP_SUMMARY
 
+    - name: Post process artifacts from jobs
+      id: autorun_post
+      run: |
+        # TODO: either use an official lcov image or create our own
+        # TODO: get rid of pandas dependency in spdk/autorun_post.py.
+        #       It's ~1GB with all it's dependecies, which is an overkill for
+        #       a few table operations.
+        sudo apt-get update && sudo apt-get install -y lcov python3-pandas
+        ./spdk/autorun_post.py -s -d ./_autorun_summary -r ./spdk
+        echo "result=success" >> "$GITHUB_OUTPUT"
+
     - name: Upload artifacts
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4.4.0
       with:
         name: _autorun_summary
         path: _autorun_summary
+    outputs:
+      result: ${{ steps.autorun_post.outputs.result }}
 
   report:
     if: ${{ always() }}
@@ -67,7 +73,10 @@ jobs:
       run: |
         vote="-1"
         message="Build failed. "
-        if [[ ${{ inputs.result }} == "success" ]]; then
+
+        # Combine results from jobs and autorun_post.py
+        if [[ "${{ inputs.result }}" == "success" && \
+                "${{ needs.merge_outputs.outputs.result }}" == "success" ]]; then
             vote="1"
             message="Build successful. "
         fi


### PR DESCRIPTION
Summary artifact will now be one stop shop for all SPDK
related artifacts, by including all job ouputs too.

While here, the pattern for upload just matched few
directories explicitly, missing files like 'completions_table.html'.
Instead just put everything into one dir pointed to by '-d',
which should include such dangling files or any future artifacts.