### PR TITLE
Rename nvmf rdma

### DIFF
--- a/.github/workflows/nvmf-rdma.yml
+++ b/.github/workflows/nvmf-rdma.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       # Required to use locally defined actions
     - name: Checkout the spdk-ci repo locally
-      uses: actions/checkout@v4
-    - name: Checkout SPDK repo from Gerrit
+      uses: actions/checkout@v4.1.7
+    - name: Prepare SPDK repo by checking out from Gerrit
       uses: ./.github/actions/checkout_gerrit
       with:
         gerrit_ref: ${{ env.gerrit_ref }}

--- a/.github/workflows/nvmf-rdma.yml
+++ b/.github/workflows/nvmf-rdma.yml
@@ -1,5 +1,5 @@
 ---
-name: nvmf-rdma-test
+name: SPDK per-patch HPE NVMe-oF RDMA tests
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ on:
         default: ''
 
 jobs:
-  hpe-nvmf-rdma:
+  nvmf-rdma-phy-autotest:
     runs-on: [hpe-rdma-vm]
     env:
       gerrit_ref: ${{ inputs.client_payload != '' && fromJson(inputs.client_payload).patchSet.ref || inputs.gerrit_ref }}
@@ -48,4 +48,4 @@ jobs:
       if: always()
       with:
         path: ./output
-        name: nvmf-rdma-vm_artifacts
+        name: hpe-job-nvmf-rdma-phy-autotest

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Download artifact tarballs
       uses: actions/download-artifact@v4.1.8
       with:
-        pattern: 'common-job-*'
+        pattern: '*-job-*-autotest'
         path: ./_autorun_summary
 
     - name: Untar the SPDK repo


### PR DESCRIPTION
Just small renames to match scheme from other workflows. Only functional change is pattern for pulling artifacts from all workflows, that will now include nvmf-phy job.

The pattern so far seems to be shaping up 'who-job-type-of-test-what-enviroment-autotest', ex:
```
common-job-nvmf-tcp-vm-autotest
common-job-release-build-gcc-container-autotest
hpe-job-nvmf-rdma-phy-autotest
```

`phy-autotest` is used due to real hardware being under test, in contrast to emulated devices. Even if the execution environment is a VM with passed VFs.