### PR TITLE
fix(autorun_in_qemu): skip guest shutdown to prevent errors

### DIFF
--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -171,9 +171,18 @@ jobs:
       if: always()
       run: |
         cd ci/cijoe
-        cijoe workflows/autorun_in_qemu.yaml output_listing retrieve_autorun_output guest_shutdown \
+        cijoe workflows/autorun_in_qemu.yaml output_listing retrieve_autorun_output \
         --config configs/qemuhost-with-guest-fedora-40.toml \
         --output report_${{ matrix.workflow }}_cleanup \
+        --monitor
+
+    - name: qemu-guest, shutdown
+      if: contains(runner.labels, 'self-hosted') || env.ACT == 'true'
+      run: |
+        cd ci/cijoe
+        cijoe workflows/autorun_in_qemu.yaml guest_shutdown \
+        --config configs/qemuhost-with-guest-fedora-40.toml \
+        --output report_${{ matrix.workflow }}_guest_shutdown \
         --monitor
 
     - name: Upload Artifacts


### PR DESCRIPTION
Graceful shutdowns (e.g., systemctl poweroff) fail intermittently, leading to errors. Since shutdown isn't required in the GitHub Runner environment, the workflow no longer calls the guest_shutdown step in the autorun_in_qemu job.

Note: In self-hosted environments, stray QEMU processes must be handled separately. The guest_shutdown step is retained for those cases, though it's unused here.