### PR TITLE
Handle more events for repository_dispatch builds

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -10,6 +10,9 @@ on:
   repository_dispatch:
     types:
     - per-patch-event
+    - patchset-created
+    - wip-state-changed
+    - private-state-changed
 
 jobs:
   common:


### PR DESCRIPTION
Use actual event names which are used in messages generated by Gerrit's Webhooks plugin to trigger repository_dispatch builds. Added items match the configuration currently enabled on Gerrit's side.

At the moment all events forwarded from Gerrit have their type replaced to "per-patch-event". We want to differentiate between the events, so this behavior will be disabled soon, along with removal of "per-patch-event" from repository_dispatch list.