### PR TITLE
gerrit: fix client_payload mapping

### DIFF
--- a/.github/workflows/gerrit-false-positives-handler.yml
+++ b/.github/workflows/gerrit-false-positives-handler.yml
@@ -13,7 +13,7 @@ on:
     - comment-added
 
 env:
-  client_payload: ${{ github.event.client_payload || inputs.client_payload || '' }}
+  client_payload: ${{ github.event.client_payload != '' && toJson(github.event.client_payload) || inputs.client_payload }}
 
 jobs:
   env_vars: # Workaround for https://github.com/actions/runner/issues/2372

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -20,7 +20,8 @@ on:
     - private-state-changed
 
 env:
-  client_payload: ${{ github.event.client_payload || inputs.client_payload || '' }}
+  # TODO: Renable client_payload for workflow_dispatch
+  client_payload: ${{ github.event.client_payload != '' && toJson(github.event.client_payload) || '' }}
 
 jobs:
   env_vars: # Workaround for https://github.com/actions/runner/issues/2372


### PR DESCRIPTION
repository_dispatch payload is an object,
it needs to be converted to string before assignment.

Otherwise following error was ocurring:
```
The template is not valid. .github/workflows/gerrit-false-positives-handler.yml (Line: 16, Col: 19): A mapping was not expected
```

Besides that the "||" statements do not behave as one might expect. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example

False positive job won't be able to do anything with empty client_payload, so throw it out.

Meanwhile per-patch was intended to test latest SPDK when client_payload is not passed. Until this is figured out just make that default behaviour and disable passing client_payload as input for manual runs.