### PR TITLE
Ignore private changes and comments

### DIFF
--- a/.github/scripts/parse_false_positive_comment.sh
+++ b/.github/scripts/parse_false_positive_comment.sh
@@ -17,7 +17,7 @@ spdk_repo=$REPO
 gerrit_comment=$COMMENT
 reported_by=$AUTHOR
 
-gerrit_url=https://review.spdk.io/a/changes
+gerrit_url=https://review.spdk.io/changes
 gerrit_format_q="o=DETAILED_ACCOUNTS&o=MESSAGES&o=LABELS&o=SKIP_DIFFSTAT"
 
 # Looking for comment thats only content is "false positive: 123", with a leeway for no spaces
@@ -47,6 +47,12 @@ curl -s -X GET \
 	--user "$GERRIT_BOT_USER:$GERRIT_BOT_HTTP_PASSWD" \
 	"$gerrit_url/spdk%2Fspdk~$change_num?$gerrit_format_q" \
 	| tail -n +2 | jq . | tee change.json
+
+if [[ ! -s change.json ]]; then
+	echo "Change $change_num not found, exiting."
+	echo "Either it's a private change or in restricted branch."
+	exit 0
+fi
 
 # Do not test any change marked as WIP
 ready_for_review="$(jq -r '.has_review_started' change.json)"

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -46,9 +46,14 @@ jobs:
         set -x
 
         # Get latest info about a change itself
-        curl -s -X GET "https://review.spdk.io/a/changes/spdk%2Fspdk~${{ env.change_num }}?o=DETAILED_ACCOUNTS&o=LABELS&o=SKIP_DIFFSTAT" \
-        --user "${{ secrets.GERRIT_BOT_USER }}:${{ secrets.GERRIT_BOT_HTTP_PASSWD }}" \
-        | tail -n +2 > change.json
+        curl -s -X GET "https://review.spdk.io/changes/spdk%2Fspdk~${{ env.change_num }}?o=DETAILED_ACCOUNTS&o=LABELS&o=SKIP_DIFFSTAT" \
+        | tail -n +2 >  change.json
+
+        if [[ ! -s change.json ]]; then
+          echo "Change ${{ env.change_num }} not found, exiting."
+          echo "Either it's a private change or in restricted branch."
+          gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
+        fi
 
         # Do not test any change marked as WIP
         ready_for_review="$(jq -r '.has_review_started' change.json)"


### PR DESCRIPTION
Do not process events from changes which are either private or belong to branches where anonymous user doesn't have access (e.g. refs/meta/config branches).

If it's not readable by anonymous user - don't run it.