### PR TITLE
false_positive: be less restrictive searching for last failed build

### DIFF
--- a/.github/workflows/gerrit-false-positives-handler.yml
+++ b/.github/workflows/gerrit-false-positives-handler.yml
@@ -92,7 +92,7 @@ jobs:
                   | select(._revision_number==${{ env.patch_set }})
                   | select(.message | test("Build failed")) | .message' change.json \
                   | grep "Results: " | tail -1 | grep -Eo 'https://github.com/[a-z0-9./_:-]*')"
-        fp_run_id="$(echo $fp_run_url | grep -oP '(?<=runs\/)[0-9]+(?=/)')"
+        fp_run_id="$(echo $fp_run_url | grep -oP '(?<=runs\/)[0-9]+')"
 
         reported_by="${{ fromJSON(needs.env_vars.outputs.client_payload).author.username }}"
 


### PR DESCRIPTION
The URL was recently changed to include run attempt, ex: https://github.com/spdk/spdk-ci/actions/runs/1234567/attempts/3

This made it impossible to rerun old builds with just the run id: https://github.com/spdk/spdk-ci/actions/runs/1234567

By simplifying the regex, both will be matched.