### PR TITLE
Do not run SPDK tests for infra changes

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
     - '.github/workflows/selftest.yml'
     - '.github/workflows/build_qcow2.yml'
+    - 'infra/**'
   workflow_dispatch:
     inputs:
       client_payload:


### PR DESCRIPTION
There's no automated tests or automated deployments for changes done in "infra" directory, so there's
no way to check if they'd affect SPDK workflows.
Thus, there's no point in running SPDK workflows
and taking runners time.