### PR TITLE
Fix patch_set_status checks

### DIFF
--- a/.github/scripts/parse_false_positive_comment.sh
+++ b/.github/scripts/parse_false_positive_comment.sh
@@ -64,7 +64,7 @@ if ((current_patch_set != patch_set)); then
 fi
 
 # False positive should be used only on changes that already have a negative Verified vote
-verified=$(jq -r ".labels.Verified.all[] | select(.username==\"$GERRIT_BOT_USER\").value" change.json)
+verified=$(jq -r ".labels.Verified.all[]? | select(.username==\"$GERRIT_BOT_USER\").value" change.json)
 if ((verified != -1)); then
 	echo "Ignore. Comment posted with no negative vote from CI."
 	exit 0

--- a/.github/scripts/parse_false_positive_comment.sh
+++ b/.github/scripts/parse_false_positive_comment.sh
@@ -49,8 +49,9 @@ curl -s -X GET \
 	| tail -n +2 | jq . | tee change.json
 
 # Do not test any change marked as WIP
-ready_for_review="$(jq -r '.has_review_started' change.json)"
-if [[ "$ready_for_review" == "false" ]]; then
+# .work_in_progress is not set when false
+work_in_progress="$(jq -r '.work_in_progress' change.json)"
+if [[ "$work_in_progress" == "true" ]]; then
 	echo "Ignore. Comment posted to WIP change."
 	exit 0
 fi

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -52,8 +52,9 @@ jobs:
         | tail -n +2 > change.json
 
         # Do not test any change marked as WIP
-        ready_for_review="$(jq -r '.has_review_started' change.json)"
-        if [[ "$ready_for_review" == "false" ]]; then
+        # .work_in_progress is not set when false
+        work_in_progress="$(jq -r '.work_in_progress' change.json)"
+        if [[ "$work_in_progress" == "true" ]]; then
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -65,8 +65,8 @@ jobs:
         fi
 
         # Test only changes without a Verified vote already present
-        verified="$(jq -r '.labels.Verified.all[] | select(.username=="${{ secrets.GERRIT_BOT_USER }}").value' change.json)"
-        if [[ "$verified" -ne 0 ]]; then
+        verified=$(jq -r ".labels.Verified.all[]? | select(.username==\"${{ secrets.GERRIT_BOT_USER }}\").value" change.json)
+        if ((verified != 0)); then
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -60,7 +60,7 @@ jobs:
 
         # Only test latest patch set
         current_patch_set="$(jq -r '.current_revision_number' change.json)"
-        if [[ "$current_patch_set" -ne ${{ env.patch_set }} ]]; then
+        if ((current_patch_set != ${{ env.patch_set }})); then
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -55,18 +55,21 @@ jobs:
         # .work_in_progress is not set when false
         work_in_progress="$(jq -r '.work_in_progress' change.json)"
         if [[ "$work_in_progress" == "true" ]]; then
+          echo "Ignore. Patch is currently WIP."
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 
         # Only test latest patch set
         current_patch_set="$(jq -r '.current_revision_number' change.json)"
         if ((current_patch_set != ${{ env.patch_set }})); then
+          echo "Ignore. Patch set ${{ env.patch_set }} is not the latest."
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 
         # Test only changes without a Verified vote already present
         verified=$(jq -r ".labels.Verified.all[]? | select(.username==\"${{ secrets.GERRIT_BOT_USER }}\").value" change.json)
         if ((verified != 0)); then
+          echo "Ignore. Patch already has a vote from CI."
           gh run cancel ${{ github.run_id }} -R ${{ github.repository }}
         fi
 


### PR DESCRIPTION
After running the patch_set_status job for a few days, there needed to be few fixes and additional comments to help narrow down the cause for skipping tests.

Especially important is the change for verified vote on completely new patch. Obviously such patch had no prior votes and while the step exited with failure, workflow was not canceled. So job proceeded as expected, just with supposedly failed step. Fixed that to fail gracefully in such case. 