### PR TITLE
mergable_changes: set merge conflicts as not ready

### DIFF
--- a/infra/mergable_changes/mergable_changes.py
+++ b/infra/mergable_changes/mergable_changes.py
@@ -55,7 +55,7 @@ class GerritChange:
         needs_plus_two = not has_minus_one and not has_merge_conflict and plus_two_crs == 1
         reviewed_by = str(next((review['name'] for review in code_reviews if review['value'] == 2), None))
 
-        if not is_submittable:
+        if not is_submittable or not is_mergeable:
             ready = False
 
         return cls(


### PR DESCRIPTION
Changes that have merge conflicts cannot be ready for submission, mark them as such.

Before this patch, a change can appear in both - read and merge conflict sections.

<img width="1418" height="1312" alt="image" src="https://github.com/user-attachments/assets/0aa5a773-6c9d-4e04-9b5c-0cc31a9e7dcc" />

https://review.spdk.io/c/spdk/spdk/+/26141
```
    "change_id": "I2912963e62596e2fa1410e4edc14921c7e25de9c",
    "subject": "nvme_bdev: flush support",
    "status": "NEW",
    "created": "2025-06-26 12:45:52.000000000",
    "updated": "2025-07-10 08:21:57.000000000",
    "submit_type": "REBASE_ALWAYS",
    "mergeable": false,
    "submittable": true,
```