### PR TITLE
Add descriptive run-names to per-patch

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -62,6 +62,10 @@ jobs:
 
         change_num="${{ fromJSON(needs.env_vars.outputs.client_payload).change.number }}"
         patch_set="${{ fromJSON(needs.env_vars.outputs.client_payload).patchSet.number }}"
+        title="${{ fromJSON(needs.env_vars.outputs.client_payload).change.subject }}"
+
+        echo "SPDK: ($change_num/$patch_set)$title" >> $GITHUB_STEP_SUMMARY
+        echo "Gerrit: <https://review.spdk.io/c/spdk/spdk/+/$change_num/$patch_set>" >> $GITHUB_STEP_SUMMARY
 
         # Get latest info about a change itself
         curl -s -X GET "https://review.spdk.io/changes/spdk%2Fspdk~$change_num?o=DETAILED_ACCOUNTS&o=LABELS&o=SKIP_DIFFSTAT" \

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -95,8 +95,6 @@ jobs:
         change_num="${{ fromJson(inputs.client_payload).change.number }}"
         patch_set="${{ fromJson(inputs.client_payload).patchSet.number }}"
 
-        echo "Gerrit: <https://review.spdk.io/c/spdk/spdk/+/$change_num/$patch_set>" >> $GITHUB_STEP_SUMMARY
-
         patch_set_date="${{ fromJson(inputs.client_payload).patchSet.createdOn }}"
         current_date="$(date +%s)"
         patch_set_turnaround="$(date -d@"$(($current_date - $patch_set_date))" -u +%Hh:%Mm:%Ss)"


### PR DESCRIPTION
This series mainly adds descriptive run-names to each execution of per-patch job.

While here, added more relevant information early in the run for easier matching to SPDK patches.

Manual run:
<img width="546" height="71" alt="image" src="https://github.com/user-attachments/assets/53545b0d-08e6-454a-ac88-b0ae59e06a18" />
SPDK-CI PR:
<img width="507" height="78" alt="image" src="https://github.com/user-attachments/assets/e39c0dd3-4343-4d5d-8cdd-0f1e18472580" />
Descriptive titles:
<img width="292" height="123" alt="image" src="https://github.com/user-attachments/assets/8b94810a-a5ad-4a5a-8e3c-3b3397e77579" />
SPDK patch trace from patch set check early in the run:
<img width="505" height="177" alt="image" src="https://github.com/user-attachments/assets/a7ff559c-98b1-445b-8e1b-df59e2e6c73b" />
