### PR TITLE
build_qcow2: make cloudinit report artifact name unique

### DIFF
--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -143,7 +143,7 @@ jobs:
       if: always()
       with:
         path: ci/cijoe/cijoe-output
-        name: cijoe-cloudinit-report
+        name: cijoe-${{ matrix.distro }}-cloudinit-report
 
     - name: Change image format and compress
       run: |


### PR DESCRIPTION
This was unfortunately missed in the [previous PR](https://github.com/spdk/spdk-ci/pull/79) meant to fix Qcow2 building process. Uploaded artifact names need to be unique in scope of the workflow unless `overwrite` is set to true (which is not the case here).