### PR TITLE
per-patch: fix run-name for Gerrit trigger

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -11,8 +11,8 @@ run-name: >-
     || github.event_name == 'workflow_dispatch' && inputs.client_payload != '' && format('Manual: ({0}/{1}){2}',
        fromJson(inputs.client_payload).change.number, fromJson(inputs.client_payload).patchSet.number, fromJson(inputs.client_payload).change.subject)
     || github.event_name == 'workflow_dispatch' && inputs.client_payload == '' && format('Manual: SPDK master')
-    || github.event_name == 'repository_dispatch' && inputs.client_payload != '' && format('({0}/{1}){2}',
-       fromJson(inputs.client_payload).change.number, fromJson(inputs.client_payload).patchSet.number, fromJson(inputs.client_payload).change.subject)
+    || github.event_name == 'repository_dispatch' && github.event.client_payload != '' && format('({0}/{1}){2}',
+       fromJson(github.event.client_payload).change.number, fromJson(github.event.client_payload).patchSet.number, fromJson(github.event.client_payload).change.subject)
   }}
 
 on:


### PR DESCRIPTION
Inputs for repository dispatch does not exist,
client_payload can be found in github.event.client_payload.