### PR TITLE
Fix per-patch client_payload parsing for workflow_dispatch

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -1,9 +1,9 @@
 ---
 name: SPDK per-patch tests
 
-# Pull request - "SPDK-CI: PR#123: Example Title
-# Workflow dispatch - Manual: (12345/5)Example Gerrit Subject
-# Repository dispatch - (12345/5)Example Gerrit Subject
+# Pull request - "SPDK-CI: PR#123: Example Title"
+# Workflow dispatch - "Manual: (12345/5)Example Gerrit Subject"
+# Repository dispatch - "(12345/5)Example Gerrit Subject"
 run-name: >-
   ${{
     github.event_name == 'pull_request' && format('SPDK-CI: PR#{0}: {1}',

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -13,6 +13,7 @@ run-name: >-
     || github.event_name == 'workflow_dispatch' && inputs.client_payload == '' && format('Manual: SPDK master')
     || github.event_name == 'repository_dispatch' && github.event.client_payload != '' && format('({0}/{1}){2}',
        github.event.client_payload.change.number, github.event.client_payload.patchSet.number, github.event.client_payload.change.subject)
+    || format('SPDK per-patch')
   }}
 
 on:

--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -12,7 +12,7 @@ run-name: >-
        fromJson(inputs.client_payload).change.number, fromJson(inputs.client_payload).patchSet.number, fromJson(inputs.client_payload).change.subject)
     || github.event_name == 'workflow_dispatch' && inputs.client_payload == '' && format('Manual: SPDK master')
     || github.event_name == 'repository_dispatch' && github.event.client_payload != '' && format('({0}/{1}){2}',
-       fromJson(github.event.client_payload).change.number, fromJson(github.event.client_payload).patchSet.number, fromJson(github.event.client_payload).change.subject)
+       github.event.client_payload.change.number, github.event.client_payload.patchSet.number, github.event.client_payload.change.subject)
   }}
 
 on:


### PR DESCRIPTION
Turns out that client_payload in workflow_dispatch is actual JSON object, not prettified JSON string.