### PR TITLE
.github/scripts: Fix gerrit authentication for POST request

### DIFF
--- a/.github/scripts/parse_false_positive_comment.sh
+++ b/.github/scripts/parse_false_positive_comment.sh
@@ -17,7 +17,7 @@ spdk_repo=$REPO
 gerrit_comment=$COMMENT
 reported_by=$AUTHOR
 
-gerrit_url=https://review.spdk.io/changes
+gerrit_url=https://review.spdk.io/a/changes
 gerrit_format_q="o=DETAILED_ACCOUNTS&o=MESSAGES&o=LABELS&o=SKIP_DIFFSTAT"
 
 # Looking for comment thats only content is "false positive: 123", with a leeway for no spaces


### PR DESCRIPTION
64c6f37b accidentally removed the auth endpoint from the url allowing only for GETs to complete successfully. However, to reset the vote on gerrit we need to authenticate to able POST a proper change.

Otherwise curl bounces back with 403.