### PR TITLE
Temporarily disable HPE NVMe-oF RDMA workflow

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -111,15 +111,15 @@ jobs:
       # "Client payload" is all of the information Gerrit webhooks sends out.
       client_payload: ${{ needs.env_vars.outputs.client_payload }}
 
-  hpe:
-    name: NVMe-oF RDMA tests
-    if: ${{ !cancelled() }}
-    needs:
-    - env_vars
-    - patch_set_status
-    uses: ./.github/workflows/nvmf-rdma.yml
-    with:
-      client_payload: ${{ needs.env_vars.outputs.client_payload }}
+  # hpe:
+  #   name: NVMe-oF RDMA tests
+  #   if: ${{ !cancelled() }}
+  #   needs:
+  #   - env_vars
+  #   - patch_set_status
+  #   uses: ./.github/workflows/nvmf-rdma.yml
+  #   with:
+  #     client_payload: ${{ needs.env_vars.outputs.client_payload }}
   # Add more jobs below if needed.
 
 
@@ -131,9 +131,10 @@ jobs:
     - env_vars
     - patch_set_status
     - common
-    - hpe
+    # - hpe
     uses: ./.github/workflows/summary.yml
     with:
       client_payload: ${{ needs.env_vars.outputs.client_payload }}
-      result: ${{ (needs.common.result == 'success' && needs.hpe.result == 'success') && 'success' || 'failure' }}
+      # result: ${{ (needs.common.result == 'success' && needs.hpe.result == 'success') && 'success' || 'failure' }}
+      result: ${{ needs.common.result == 'success' && 'success' || 'failure' }}
     secrets: inherit


### PR DESCRIPTION
HPE runners will be offline between 15th and 20th
August. Temporarily remove NVMe-oF RDMA tests from the workflow.