### PR TITLE
build_qcow: update the fedora 40 cloud image url

### DIFF
--- a/cijoe/configs/qemuhost-with-guest-fedora_40.toml
+++ b/cijoe/configs/qemuhost-with-guest-fedora_40.toml
@@ -42,7 +42,7 @@ bin = "qemu-system-x86_64"
 #
 [system-imaging.images.fedora_40-x86_64]
 system_label = "x86_64"
-cloud.url = "https://mirror.netsite.dk/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
+cloud.url = "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
 cloud.path = "{{ local.env.HOME }}/system_imaging/cloud/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
 cloud.metadata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-metadata'] }}"
 cloud.userdata_path = "{{ resources.auxiliary['system_imaging.cloudinit-linux-common-userdata'] }}"


### PR DESCRIPTION
Netsite no longer hosts mirrors of the Fedora Cloud images.