### PR TITLE
ci: uploading coverage to codecov.io

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -40,6 +40,11 @@ on:
 #   # Workaround for https://github.com/actions/runner/issues/2372
 #   client_payload: ${{ github.event.client_payload != '' && toJson(github.event.client_payload) || '' }}
 
+permissions:
+  actions: write  # Required for gh run cancel in patch_set_status
+  id-token: write # Required for Codecov OIDC in the summary workflow
+  contents: read
+
 jobs:
 
   patch_set_status:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -13,6 +13,10 @@ on:
         type: string
         default: 'failure'
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   merge_outputs:
     # 22.04 used on purpose; it has lcov+gcov versions that are compatible with what
@@ -60,6 +64,7 @@ jobs:
         # Now can run post processing
         ./autorun_post.py -d ../_autorun_summary -r ./
         echo "result=success" >> "$GITHUB_OUTPUT"
+        echo "spdk_sha=$(git -C ./spdk rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Upload artifacts
       if: ${{ always() }}
@@ -67,6 +72,17 @@ jobs:
       with:
         name: _autorun_summary
         path: _autorun_summary
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5.5.2
+      with:
+        fail_ci_if_error: true
+        use_oidc: true
+        disable_search: true
+        files: ./_autorun_summary/ut_coverage/ut_cov_total.info
+        override_commit: ${{ steps.autorun_post.outputs.spdk_sha }}
+        slug: spdk/spdk
+
     outputs:
       result: ${{ steps.autorun_post.outputs.result }}
 


### PR DESCRIPTION
Add Codecov integration to the summary workflow to upload combined
coverage report (ut_cov_total.info) for the spdk/spdk repository.

- Use OIDC authentication (no static token needed)
- Use override_commit to map coverage to the tested SPDK commit
- Use disable_search to only upload the specified file
- Add permissions block to gerrit-webhook-handler.yml so the
  id-token:write permission propagates to the summary workflow


see example : https://app.codecov.io/gh/glimchb/spdk
and badge :  [![codecov](https://codecov.io/gh/glimchb/spdk/graph/badge.svg?token=2U9NXR71T0)](https://codecov.io/gh/glimchb/spdk)
