### PR TITLE
Build doxygen from source in Fedora 40 images

### DIFF
--- a/cijoe/workflows/build_fedora_40_qcow2_using_qemu.yaml
+++ b/cijoe/workflows/build_fedora_40_qcow2_using_qemu.yaml
@@ -77,7 +77,7 @@ steps:
   run: |
     /tmp/spdk/scripts/pkgdep.sh -a
     mkdir /tmp/git_repos
-    /tmp/spdk/test/common/config/autotest_setup.sh --install-deps --upgrade --dir-git="/tmp/git_repos" --test-conf="lcov,flamegraph,fio,nvmecli,bpftrace,qemu"
+    /tmp/spdk/test/common/config/autotest_setup.sh --install-deps --upgrade --dir-git="/tmp/git_repos" --test-conf="lcov,flamegraph,fio,nvmecli,bpftrace,qemu,doxygen"
     rm -r /tmp/git_repos
 
 - name: guest_shutdown


### PR DESCRIPTION
Freeze doxygen version by building and installing
it from source. This will help reduce spdk.github.io diff caused by version changes.