### PR TITLE
distro: immediately cancel remaining jobs on failure

### DIFF
--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -81,7 +81,6 @@ jobs:
     - checkout_spdk
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         # Keep latest 2 versions of each flavor here
         distro:


### PR DESCRIPTION
All other jobs in this workflow are canceled when any of the fails. Without this, all distro tests take up CI time for a result that will still produce a negative vote.