### PR TITLE
Fix jq multi-line typo

### DIFF
--- a/.github/workflows/gerrit-webhook-handler.yml
+++ b/.github/workflows/gerrit-webhook-handler.yml
@@ -105,7 +105,7 @@ jobs:
         fi
 
         # Get list of files to skip some tests later depending on what files were touched
-        echo "changed_files=$(jq -r '.revisions[].files | keys' change.json)" >> "$GITHUB_OUTPUT"
+        echo "changed_files=$(jq -c -r '.revisions[].files | keys' change.json)" >> "$GITHUB_OUTPUT"
 
   common:
     name: Common tests


### PR DESCRIPTION
Error: Unable to process file command 'output' successfully.