### PR TITLE
Gh act improvements

### DIFF
--- a/.github/workflows/reupload_qcow2.yml
+++ b/.github/workflows/reupload_qcow2.yml
@@ -66,7 +66,7 @@ jobs:
 
     # Script from https://github.com/actions/cache "Tips and workarounds" section
     - name: Delete previous caches
-      if: env.artifact_id != ''
+      if: env.artifact_id != '' && ! contains(github.actor, 'nektos/act')
       run: |
         cache_id=$(gh cache list --repo ${{ github.repository }} --key "vm-image-${{ matrix.distro }}_x86_64" --json id --jq '.[].id')
         if [[ -n "$cache_id" ]]; then

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -233,12 +233,11 @@ jobs:
     # ghcr.io/spdk/spdk-ci:fedora_43 is about ~10GB in size, leaving us with not much space
     # for tests after pulling the image. Reclaim some by removing features not used in SPDK tests
     # See: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-    # Run this ONLY on self-hosted runners and make sure it's not a local GH ACT runner (these
+    # Run this ONLY on github-hosted runners and make sure it's not a local GH ACT runner (these
     # identify themselves as "github-hosted" runners!)
     - name: Cleanup runner
-      if: ${{ contains(runner.environment, 'github-hosted') }}
+      if: ${{ contains(runner.environment, 'github-hosted') && ! contains(github.actor, 'nektos/act') }}
       run: |
-        [[ $GITHUB_ACTOR == "nektos/act" || ACT == "true" ]] && exit 0
         rm -rf /host-usr-share/dotnet \
           /host-usr-local/lib/android \
           /host-usr-local/share/edge_driver \

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -323,7 +323,7 @@ jobs:
         --monitor
 
     - name: qemu-guest, shutdown
-      if: ${{ contains(matrix.workflow.name, 'vm') && contains(runner.labels, 'self-hosted') || env.ACT == 'true' }}
+      if: contains(matrix.workflow.name, 'vm') && (contains(runner.labels,'self-hosted') || contains(github.actor, 'nektos/act'))
       run: |
         cd ci/cijoe
         cijoe workflows/autorun.yaml guest_shutdown \

--- a/.github/workflows/spdk-common-tests.yml
+++ b/.github/workflows/spdk-common-tests.yml
@@ -92,7 +92,7 @@ jobs:
         freebsd_14=$(gh api --paginate "/repos/${{ github.repository }}/actions/artifacts?name=vm-image-freebsd_14_x86_64" -q '.artifacts |= sort_by(.updated_at)[-1] | .artifacts.workflow_run.id')
         [[ -z "${fedora_43}" ]] && echo "fedora_43 is empty" && exit 1
         [[ -z "${freebsd_14}" ]] && echo "freebsd_14 is empty" && exit 1
-        echo "artifact_id={'fedora_43':$fedora_43,'freebsd_14':$freebsd_14}" >> "$GITHUB_OUTPUT"
+        echo "artifact_id={\"fedora_43\":$fedora_43,\"freebsd_14\":$freebsd_14}" >> "$GITHUB_OUTPUT"
     outputs:
       artifact_id: ${{ steps.get_artifact_id.outputs.artifact_id }}
 

--- a/README.md
+++ b/README.md
@@ -91,3 +91,17 @@ run a workflow using repository_dispatch event (example events provided in `.git
 ```
 
 for more examples, visit <https://nektosact.com/>
+
+Some of the workflow (like for example build_docker.yml or gerrit-false-positives-handler.yml) require the GitHub CLI to be installed,
+which is not included in the default act containers (e.g. catthehacker/ubuntu:act-latest). To run these workflows and not encounter
+"command not found" errors, you can use the Dockerfile in `act` directory:
+
+```bash
+docker build -t spdk-act ./act
+```
+
+and then use this image to replace the default act image during workflow execution:
+
+```bash
+gh act -P ubuntu-latest=spdk-act:latest --job build-docker  --input distro=fedora_43
+```

--- a/README.md
+++ b/README.md
@@ -53,15 +53,14 @@ or manage artifacts of the SPDK CI repository, shall be placed in `.github/actio
 
 ## Locally testing actions
 
-install see <https://nektosact.com/installation>
-
-or use [GitHub CLI](https://cli.github.com/)
+### Installation
+See: <https://nektosact.com/installation> or use [GitHub CLI](https://cli.github.com/) to install the extension.
 
 ```bash
 gh extension install https://github.com/nektos/gh-act
 ```
 
-list all actions
+### Listing jobs and workflows
 
 ```bash
 $ gh act --list
@@ -78,13 +77,14 @@ Stage  Job ID          Job name        Workflow name                Workflow fil
 2      report          report          SPDK per-patch common tests  spdk-common-tests.yml       workflow_dispatch,workflow_call
 ```
 
-run all common tests
+### Running jobs and workflows
 
+Running common tests with a workflow_dispatch event:
 ```bash
  $ gh act --job tests --secret GITHUB_TOKEN=$(gh auth token) workflow_dispatch
 ```
 
-run a workflow using repository_dispatch event (example events provided in `.github/example_events`)
+Running a workflow using repository_dispatch event (example events provided in `.github/example_events`):
 
 ```bash
  $ gh act --job parse_comment --secret GITHUB_TOKEN=$(gh auth token) -e .github/example_events/comment-added.json repository_dispatch

--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ See: <https://nektosact.com/installation> or use [GitHub CLI](https://cli.github
 gh extension install https://github.com/nektos/gh-act
 ```
 
+### Before running locally
+
+Workflows containing jobs executing SPDK tests (like `spdk-common-tests.yml`) require a qcow2 image to be available.
+`spdk-common-tests.yml` will attempt to download the qcow2 image from local `gh act` cache or from GitHub Actions artifacts,
+and will do so for every workflow execution.
+
+It is advised to have a local copy of Qcow2 artifacts to reduce the need to download them from Github Actions every time.
+
+In order to do so:
+
+* If using a forked `spdk-ci` repository:
+    * Build the images using `SPDK-CI build VM image` in your forked repository. This workflow witll archive and cache the
+    images on Github side.
+    * Optionally follow up with `SPDK-CI build Docker image` as well, so that Qcow2 images are converted into Docker images
+    and uploaded to ghcr.io associated with your forked repository.
+    * Locally, using `gh act` run `Reupload qcow2 vm images` workflow.
+    This will download a copy of the images from your forked repository's Github Actions and cache them locally.
+
+    ```bash
+    $ gh act --artifact-server-path=$HOME/.cache/act -W .github/workflows/reupload_qcow2.yml -v workflow_dispatch
+    ```
+    `--cache-server-path` has a default value, so does not have to be provided in the command.
+* If using a clone of `spdk/spdk-ci` repository:
+    * Run `Reupload qcow2 vm images` workflow as in the exemple in previous point.
+
 ### Listing jobs and workflows
 
 ```bash

--- a/act/Dockerfile
+++ b/act/Dockerfile
@@ -1,0 +1,2 @@
+FROM catthehacker/ubuntu:act-latest
+RUN apt-get update && apt-get install -y gh

--- a/cijoe/workflows/build_fedora_qcow2_using_qemu.yaml
+++ b/cijoe/workflows/build_fedora_qcow2_using_qemu.yaml
@@ -54,7 +54,7 @@ steps:
 - name: guest_update
   run: |
     dnf update -y
-    dnf install -y git perl-JSON-PP
+    dnf install -y git perl-JSON-PP nodejs
     dnf autoremove -y
     dnf clean all -y
 

--- a/cijoe/workflows/build_freebsd_14_qcow2_using_qemu.yaml
+++ b/cijoe/workflows/build_freebsd_14_qcow2_using_qemu.yaml
@@ -58,7 +58,7 @@ steps:
 
 - name: guest_update
   run: |
-    pkg install -y git
+    pkg install -y git nodejs
 
 - name: kernel_src
   run: |


### PR DESCRIPTION
Series of changes improving running workflows locally using `gh act`.

Explanations here to avoid going into commit messages:
* Add a Dockerfile to allow users quickly creating local version of runner images with Github CLI tool installed. Default act images don't have it in "slim" images (and we don't want to use "full" images as they are 30+GB in size)
* Add nodejs to list of packages installed by CI Joe into Qcow2 images. Nodejs is needed by some of the actions we use. It doesn't take much space, so won't bloat the images very much.
* Fix exporting `artifact_id` in common tests workflow - there was an issue with quoting which `gh act` JSON parser was complaining about. Interestingly - this worked in Github which might suggest different JSON parsers?
* Don't use github.token to avoid downloading Qcow2 image on each run when using `gh act`
* CI Joe image upgrade was aimed at using configuration files override as described [here](https://cijoe.readthedocs.io/en/latest/configs/index.html#defining-multiple-configuration-files). Ultimately this was not needed as I've found different way to solve `disk.path` problem of .toml file, but decided to keep the version upgrade anyway.