### PR TITLE
Handle mergable_changes connection exceptions

### DIFF
--- a/infra/mergable_changes/mergable_changes.py
+++ b/infra/mergable_changes/mergable_changes.py
@@ -6,9 +6,10 @@ import time
 import jinja2
 import logging
 import datetime
+import sys
 from typing import Dict
 from prettytable import PrettyTable
-from requests import RequestException
+from requests import RequestException, ConnectionError
 from pygerrit2 import GerritRestAPI
 
 @dataclass
@@ -134,7 +135,12 @@ def get_gerrit_changes(gerrit, all_changes):
         "/changes/", "?q=project:spdk/spdk status:open label:Code-Review=2 label:Verified=1",
         "&o=CURRENT_REVISION", "&o=DETAILED_LABELS", "&o=DETAILED_ACCOUNTS", "&o=SUBMITTABLE"
     ])
-    changes_json = gerrit.get(query)
+    try:
+        changes_json = gerrit.get(query)
+    except ConnectionError as conn_exception:
+        logging.exception(conn_exception)
+        sys.exit(1)
+
     for change_json in changes_json:
         change = GerritChange.from_json(change_json)
         all_changes.append(change)


### PR DESCRIPTION
In case of connection issues to Gerrit pygerrit2 already
handles "NewConnectionError" 5 times (by default) in a row
when attempting to query. After that "NewConnectionError"
is being raised, and it was not handled.
Let's catch the exception ourselves and log it before
exiting from script.