### PR TITLE
infra: remove "version" from docker-compose.yml

### DIFF
--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   nginx:
     image: nginx:1.29.8


### PR DESCRIPTION
"version" was deprecated and is no longer requrired to be specified in the compose file.
