### PR TITLE
infra: Enable Nginx log rotation and dual logging

### DIFF
--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -2,9 +2,12 @@
 version: '3.9'
 services:
   nginx:
-    image: nginx:1.29.8
     container_name: nginx
     restart: always
+    image: nginx-gerrit:latest
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
     ports:
     - "443:443"
     depends_on:

--- a/infra/nginx/Dockerfile
+++ b/infra/nginx/Dockerfile
@@ -1,0 +1,15 @@
+FROM nginx:1.29.8
+
+# Remove sym links from nginx image
+# These by default redirect to /dev/stdout and /dev/stderr
+RUN rm /var/log/nginx/access.log
+RUN rm /var/log/nginx/error.log
+
+RUN apt-get update && apt-get -y install logrotate
+
+COPY nginx-logrotate.conf /etc/logrotate.d/nginx
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+CMD [ "/entrypoint.sh" ]

--- a/infra/nginx/entrypoint.sh
+++ b/infra/nginx/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cron
+exec nginx -g "daemon off;"

--- a/infra/nginx/nginx-logrotate.conf
+++ b/infra/nginx/nginx-logrotate.conf
@@ -1,0 +1,15 @@
+/var/log/nginx/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    delaycompress
+    notifempty
+    create 640 root root
+    sharedscripts
+    postrotate
+            if [ -f /run/nginx.pid ]; then
+                    kill -USR1 `cat /run/nginx.pid`
+            fi
+    endscript
+}

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -2,6 +2,12 @@ server {
     listen 443 ssl;
     server_name review.spdk.io;
 
+    access_log /var/log/nginx/access.log;
+    access_log /dev/stdout;
+
+    error_log /var/log/nginx/error.log;
+    error_log /dev/stderr;
+
     if ($http_user_agent ~* (ImagesiftBot|Bytespider|GPTBot|bingbot|Petalbot|SemrushBot|DuckAssistBot) ) {
         return 403;
     }
@@ -45,5 +51,11 @@ server {
 server {
     listen 80 default_server;
     server_name _;
+
+    access_log /var/log/nginx/access.log;
+    access_log /dev/stdout;
+    error_log /var/log/nginx/error.log;
+    error_log /dev/stderr;
+
     return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
Currently, the Nginx container symlinks its log files to stdout/stderr.
This allows `docker logs` to work but makes long-term log inspection difficult.
                                      
This commit improves log management by:
* Removing the default symlinks to /dev/stdout and /dev/stderr.
* Configuring Nginx to write logs to both standard streams and local files.
* Setting up `logrotate` within the container to rotate the local files daily.
 
This approach keeps `docker logs` functional while providing organized,
rotated files for easier historical debugging.

