### PR TITLE
infra: template nginx configuration file

### DIFF
--- a/infra/.env.nginx.example
+++ b/infra/.env.nginx.example
@@ -1,0 +1,2 @@
+NGINX_CERT_DIR=/etc/letsencrypt
+NGINX_STATIC_DIR=/var/www/ci.spdk.io

--- a/infra/.env.nginx.example
+++ b/infra/.env.nginx.example
@@ -1,2 +1,3 @@
 NGINX_CERT_DIR=/etc/letsencrypt
 NGINX_STATIC_DIR=/var/www/ci.spdk.io
+NGINX_SSL_DOMAIN_NAME=localhost

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,1 +1,2 @@
 .env
+.env.nginx

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -11,12 +11,18 @@ services:
       gerrit:
         condition: service_healthy
     volumes:
-    - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    - ./nginx/nginx.conf.template:/etc/nginx/conf.d/default.conf.template:ro
     - outputs:/var/www/outputs:ro
     - ${NGINX_CERT_DIR:-/etc/letsencrypt}:/etc/letsencrypt:ro
     - ${NGINX_STATIC_DIR:-/var/www/ci.spdk.io}:/var/www/localhost:ro
     networks:
     - gerrit
+    command:
+    - /bin/bash
+    - -c
+    - |
+      envsubst '$${NGINX_SSL_DOMAIN_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+      exec nginx -g 'daemon off;'
 
   gerrit:
     image: gerritcodereview/gerrit:3.14.0

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     image: nginx:1.31.2
     container_name: nginx
     restart: always
+    env_file: ".env.nginx"
     ports:
     - "443:443"
     depends_on:

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -6,8 +6,8 @@ server {
         return 403;
     }
 
-    ssl_certificate /etc/letsencrypt/live/localhost/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/localhost/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${NGINX_SSL_DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${NGINX_SSL_DOMAIN_NAME}/privkey.pem;
     ssl_protocols       TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 


### PR DESCRIPTION
ssl_certificate and ssl_certificate_key paths in nginx
configuration file are quite probably not "localhost"
when running things in production and will be using
the actual domain's directory.

Use .env.nginx and envsubst to create a config file
with ssl options potining to correct directory.
