### PR TITLE
ci: skip CI for patches with [RFC] in subject

### DIFF
--- a/.github/scripts/parse_false_positive_comment.sh
+++ b/.github/scripts/parse_false_positive_comment.sh
@@ -61,6 +61,13 @@ if [[ "$work_in_progress" == "true" ]]; then
 	exit 0
 fi
 
+# Do not retest [RFC] patches
+subject="$(jq -r '.subject' change.json)"
+if [[ "${subject,,}" == *"[rfc]"* ]]; then
+	echo "::notice title=Skipped::Comment posted to [RFC] change."
+	exit 0
+fi
+
 # Only test latest patch set
 current_patch_set="$(jq -r '.current_revision_number' change.json)"
 if ((current_patch_set != patch_set)); then

--- a/.github/scripts/parse_gerrit_webhook.sh
+++ b/.github/scripts/parse_gerrit_webhook.sh
@@ -22,6 +22,12 @@ if [[ "$work_in_progress" == "true" ]]; then
     gh run cancel "${GITHUB_RUN_ID}" -R "${GITHUB_REPOSITORY}"
 fi
 
+# Do not test any change with [RFC] in the subject
+if [[ "${TITLE,,}" == *"[rfc]"* ]]; then
+    echo "Ignore. Patch subject contains [RFC]." >> "${GITHUB_STEP_SUMMARY}"
+    gh run cancel "${GITHUB_RUN_ID}" -R "${GITHUB_REPOSITORY}"
+fi
+
 # Only test latest patch set
 current_patch_set="$(jq -r '.current_revision_number' change.json)"
 if ((current_patch_set != PATCH_SET)); then

--- a/infra/forwarder/forwarder.py
+++ b/infra/forwarder/forwarder.py
@@ -345,6 +345,11 @@ def _should_drop_event(event_data):
     if status is not None and status != "NEW":
         return True, f"status={status}"
 
+    # Drop patches with [RFC] in the commit subject (case-insensitive)
+    subject = event_data.get("payload", {}).get("change", {}).get("subject", "")
+    if re.search(r"\[RFC\]", subject, re.IGNORECASE):
+        return True, "rfc"
+
     return False, None
 
 


### PR DESCRIPTION
The SPDK documentation states that patches containing [RFC] in the commit message header should not be run through the CI system, but this was never implemented. Add [RFC] subject checking at all CI entry points:

- forwarder.py _should_drop_event(): drop events early before dispatching to GitHub Actions
- parse_gerrit_webhook.sh: cancel workflow if subject contains [RFC]
- parse_false_positive_comment.sh: skip retriggering for RFC patches

Fixes: https://github.com/spdk/spdk/issues/3912

Generated with [Devin](https://devin.ai)